### PR TITLE
refactor: remove specs directory references from documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -69,7 +69,6 @@ Dockerfile*
 *.md
 !README.md
 docs/
-specs/
 
 # Temporary files
 /tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,22 +24,14 @@ Auto-generated from all feature plans. Last updated: 2025-10-18
 - Redis (job state for async), filesystem (temporary uploaded files) (007-ocrmac-livetext-option)
 
 ## Project Structure
+
 ```
 src/                    # Application source code
-├── main.py            # FastAPI app entry point
-├── config.py          # Pydantic settings
-├── models/            # Data models
-├── api/               # API routes and middleware
-├── services/          # Business logic
-└── utils/             # Shared utilities
 tests/                 # Test suite (TDD)
-├── unit/              # Unit tests
-├── integration/       # Integration tests
-├── contract/          # OpenAPI contract tests
-└── performance/       # Performance tests
 samples/               # Test fixtures
-specs/                 # Design documentation
 ```
+
+For detailed project structure with explanations of each directory, see [CONTRIBUTING.md - Project Structure](CONTRIBUTING.md#project-structure).
 
 ## Commands
 
@@ -102,25 +94,24 @@ redis-cli flushdb
 ```
 
 ## Code Style
-Python 3.11+: Follow PEP 8 conventions, enforced via ruff and pyright
+
+**Quick Reference** - See [CONTRIBUTING.md - Code Style](CONTRIBUTING.md#code-style-guidelines) for detailed guidelines and examples.
 
 ### Key Conventions
-- Use type hints for all function parameters and return values (enforced by pyright)
+- Python 3.11+ following PEP 8 (enforced via ruff and pyright)
+- Type hints required for all function parameters and return values
 - Pydantic models for all data validation
 - Async/await for I/O operations
 - Structured logging with structlog (JSON format)
-- 80% overall test coverage, 90% for utilities
+- Coverage targets: 80% overall, 90% for utilities
 
 ### Pre-commit Hooks
 Automatically run before each commit:
-- **Standard checks**: trailing whitespace, end-of-file fixer, YAML/JSON/TOML validation
-- **Ruff**: auto-format code and fix linting issues
-- **Pyright**: type checking (currently has 80 errors - work in progress)
+- Standard checks (whitespace, EOF, YAML/JSON/TOML validation)
+- Ruff (auto-format and fix linting)
+- Pyright (type checking - currently 80 errors, work in progress)
 
-**Note**: Commits will be blocked if pyright finds type errors. To bypass temporarily:
-```bash
-git commit --no-verify -m "message"  # Skip hooks (use sparingly)
-```
+**Bypass hooks** (use sparingly): `git commit --no-verify -m "message"`
 
 ## Recent Changes
 - 007-ocrmac-livetext-option: Added Python 3.11+ + FastAPI 0.104+, Pydantic 2.5+, pytesseract 0.3+, ocrmac 0.1+ (with framework parameter support), Redis 7.0+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,6 @@ restful-ocr/
 │   ├── contract/          # OpenAPI contract tests
 │   └── performance/       # Performance benchmarks
 ├── samples/               # Test fixtures and sample documents
-├── specs/                 # Design documentation and specifications
 ├── pyproject.toml         # Project metadata and dependencies
 ├── docker-compose.yml     # Docker stack configuration
 └── Dockerfile             # API container image
@@ -127,8 +126,6 @@ This project follows **Test-Driven Development (TDD)** principles. All contribut
    - Continue with the next feature or bug fix
 
 ### Detailed TDD Workflow
-
-For a comprehensive guide on the TDD workflow used in this project, see [specs/001-ocr-hocr-upload/quickstart.md](specs/001-ocr-hocr-upload/quickstart.md).
 
 ### Branch Naming Convention
 
@@ -173,6 +170,8 @@ Closes #123
 ## Testing
 
 Testing is a critical part of our development process. All contributions must include appropriate tests.
+
+> **Quick Command Reference**: For a quick reference of all development commands (testing, formatting, type checking, Docker, etc.), see [AGENTS.md](AGENTS.md).
 
 ### Running Tests
 
@@ -307,11 +306,20 @@ class JobStatus(BaseModel):
 
 ### Type Checking
 
-Use type hints and consider running mypy for type checking:
+This project uses [Pyright](https://github.com/microsoft/pyright) for static type checking. All code should include type hints:
 
 ```bash
-uv run mypy src/
+# Run type checker
+uv run pyright
+
+# Check specific directory
+uv run pyright src/
+
+# Watch mode for continuous checking
+uv run pyright --watch
 ```
+
+**Note**: Type checking is automatically run via pre-commit hooks. See [AGENTS.md](AGENTS.md) for pre-commit hook configuration and commands.
 
 ## Submitting Changes
 
@@ -433,22 +441,25 @@ What would make this feature complete?
 - [ ] Criterion 2
 ```
 
-## Development Resources
+## Platform Limitations
 
-- **Specifications**: See `specs/` directory for detailed design docs
-- **API Contract**: `specs/001-ocr-hocr-upload/contracts/openapi.yaml`
-- **FastAPI Documentation**: https://fastapi.tiangolo.com/
-- **Pytest Documentation**: https://docs.pytest.org/
-- **Ruff Documentation**: https://github.com/astral-sh/ruff
+### macOS-specific Dependencies
+
+The `ocrmac` package provides access to Apple's Vision and LiveText OCR frameworks but has important limitations:
+
+- **Docker Incompatibility**: ocrmac requires macOS-native frameworks that are unavailable in Docker containers (even on Mac hosts)
+- **Local Development**: Works only when running the application natively on macOS
+- **Alternative Engines**: Tesseract and EasyOCR work in all environments including Docker
+
+For detailed platform requirements and limitations, see the [Platform Limitations section in AGENTS.md](AGENTS.md#platform-limitations).
 
 ## Questions?
 
 If you have questions about contributing:
 
-1. Check existing documentation in `specs/`
-2. Search closed issues for similar questions
-3. Open a new issue with the "question" label
-4. Join community discussions (if available)
+1. Search closed issues for similar questions
+2. Open a new issue with the "question" label
+3. Join community discussions (if available)
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -14,41 +14,6 @@ A high-performance RESTful API service for document OCR processing with HOCR (HT
 
 ## Quick Start
 
-### Prerequisites
-
-- Python 3.11+
-- Redis 7.0+
-- Tesseract OCR 5.3+
-- Poppler utils (for PDF processing)
-- uv (Python package manager)
-
-### Installation
-
-```bash
-# Clone the repository
-git clone <repository-url>
-cd restful-ocr
-
-# Install system dependencies (Ubuntu/Debian)
-sudo apt-get update
-sudo apt-get install -y tesseract-ocr tesseract-ocr-eng poppler-utils redis-server
-
-# Create virtual environment and install dependencies
-uv venv
-source .venv/bin/activate
-uv sync --group dev
-
-# Create required directories
-mkdir -p /tmp/uploads /tmp/results
-chmod 700 /tmp/uploads /tmp/results
-
-# Copy environment configuration
-cp .env.example .env
-
-# Start Redis
-sudo systemctl start redis
-```
-
 ### Running with Docker Compose (Recommended)
 
 ```bash
@@ -62,15 +27,17 @@ docker compose logs -f api
 docker compose down
 ```
 
-### Running Locally
-
+The API will be available at `http://localhost:8000`. Check the health endpoint to verify:
 ```bash
-# Development mode (auto-reload)
-uv run uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
-
-# Production mode (4 workers)
-uv run uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 4
+curl http://localhost:8000/health
 ```
+
+### Development Setup
+
+For local development without Docker, or to contribute to the project, see the [Contributing Guide](CONTRIBUTING.md) for detailed setup instructions including:
+- Installing dependencies (Python, Redis, Tesseract, etc.)
+- Setting up your development environment
+- Running tests and code quality tools
 
 ## API Usage
 
@@ -159,22 +126,16 @@ All configuration is via environment variables (see `.env.example`):
 - **Logging**: structlog (JSON format)
 - **Metrics**: Prometheus client
 
-## Platform-Specific Dependencies
+## Platform Notes
 
-### ocrmac (macOS Only)
+### macOS OCR Engine
 
-The `ocrmac` package is conditionally installed on macOS via the dependency specification:
-```python
-"ocrmac>=0.1.0; sys_platform == 'darwin'"
-```
+This API includes support for macOS's native Vision and LiveText OCR frameworks when running natively on macOS. However, these features are **not available in Docker containers** due to macOS framework limitations.
 
-**Important**: `ocrmac` requires Apple's Vision framework, which is **unavailable in Docker containers** (even on Mac). Docker runs a Linux VM, so containers cannot access macOS-native frameworks. This means:
+- When running in Docker (recommended): Tesseract and EasyOCR engines are available
+- When running natively on macOS: All engines including ocrmac (Vision/LiveText) are available
 
-- ✅ **Local macOS development**: ocrmac works when running the application directly on macOS
-- ❌ **Docker containers**: ocrmac is not available in Docker, regardless of host OS
-- ✅ **Linux/Windows**: Application runs fine without ocrmac (Tesseract/EasyOCR available)
-
-If you need macOS Vision framework features, run the application natively on macOS without Docker. For containerized deployments, use Tesseract or EasyOCR engines instead.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on platform-specific limitations.
 
 ## Deployment
 
@@ -289,13 +250,6 @@ Minimum per instance:
 - **Memory**: 2GB RAM (4GB+ recommended)
 - **Storage**: 10GB for temp files + results
 - **Redis**: 512MB RAM minimum
-
-## Documentation
-
-- **Specification**: [specs/001-ocr-hocr-upload/spec.md](specs/001-ocr-hocr-upload/spec.md)
-- **Implementation Plan**: [specs/001-ocr-hocr-upload/plan.md](specs/001-ocr-hocr-upload/plan.md)
-- **Quickstart Guide**: [specs/001-ocr-hocr-upload/quickstart.md](specs/001-ocr-hocr-upload/quickstart.md)
-- **OpenAPI Contract**: [specs/001-ocr-hocr-upload/contracts/openapi.yaml](specs/001-ocr-hocr-upload/contracts/openapi.yaml)
 
 ## Contributing
 


### PR DESCRIPTION
Updated AGENTS.md, CONTRIBUTING.md, and README.md to remove mentions of the specs directory, streamlining project documentation. Added quick reference links to relevant sections for better navigation.

Note: Commit message generated with AI assistance.